### PR TITLE
common: Reserve pl memory from shared dma pool

### DIFF
--- a/common/al_codec.c
+++ b/common/al_codec.c
@@ -19,6 +19,7 @@
 
 #include <linux/delay.h>
 #include <linux/of_address.h>
+#include <linux/of_reserved_mem.h>
 #include <linux/of.h>
 
 #include "al_mail.h"
@@ -410,6 +411,18 @@ int al5_codec_set_up(struct al5_codec_desc *codec, struct platform_device *pdev,
 		dev_err(&pdev->dev, "Can't map registers");
 		err = PTR_ERR(codec->regs);
 		goto fail;
+	}
+
+	err = of_reserved_mem_device_init(&pdev->dev);
+	if (err) {
+		dev_dbg(&pdev->dev, "Failed to get shared dma pool with error : %d\n", err);
+	} else {
+		dev_dbg(&pdev->dev, "Using shared dma pool for allocation\n");
+		err = dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(64));
+		if (err) {
+			dev_err(&pdev->dev, "dma_set_coherent_mask: %d\n", err);
+			goto fail;
+		}
 	}
 
 	mem_node = of_parse_phandle(pdev->dev.of_node, "xlnx,dedicated-mem", 0);


### PR DESCRIPTION
Check if shared dma pool is available and use that for dma allocation.
Set DMA mask to 64bits as allocating from 64bit address-space.
This patch helps to reduce the Allocation time, as memory is reserved at boot time

Signed-off-by: Rohit Visavalia <rohit.visavalia@xilinx.com>