### PR TITLE
fix bad check for dmabuf export

### DIFF
--- a/common/al_dmabuf.c
+++ b/common/al_dmabuf.c
@@ -283,7 +283,7 @@ static struct dma_buf *al5_get_dmabuf(void *dma_info_priv)
 		return NULL;
 
 	dbuf = dma_buf_export(&exp_info);
-	if (IS_ERR(buf)) {
+	if (IS_ERR_OR_NULL(dbuf)) {
 		pr_err("couldn't export dma buf\n");
 		return NULL;
 	}


### PR DESCRIPTION
this change corrects a probable copy/paste error which may have lead to undesired functionality in the erroring program path.

Note that `buf` has been replaced with `dbuf` as well.