### PR TITLE
Fix warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ registers interface and make it possible to handle interrupts in userspace.
 ## Building
 
 To build drivers you need a linux kernel build tree. Give location of
-kernel build tree using KDIR environment variable.
+kernel build tree using KERNEL_SRC environment variable.
 It you are cross-compiling then define ARCH and CROSS\_COMPILE environment
 variable.
+The `KERNEL_SRC` directory must contain a `.config` and should be prepared with `make modules_prepare`.
 
 ```
-$ ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- KDIR=linux-headers-dir make
+$ ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- KERNEL_SRC=linux-headers-dir make
 ```
 
 Compiled kernel modules are located in al5r/al5r.ko

--- a/microblaze/al5d/dec_mails_factory.c
+++ b/microblaze/al5d/dec_mails_factory.c
@@ -28,8 +28,8 @@ void al5d_mail_get_sc_status(struct al5_scstatus *scstatus,
 	memcpy(scstatus, mail->body + 4, sizeof(*scstatus));
 }
 
-void write_decode_mail(struct al5_mail *mail, u32 chan_uid,
-		       struct al5_decode_msg *msg)
+static void write_decode_mail(struct al5_mail *mail, u32 chan_uid,
+			      struct al5_decode_msg *msg)
 {
 	al5_mail_write_word(mail, chan_uid);
 	al5_mail_write(mail, msg->params.opaque, msg->params.size);

--- a/microblaze/common/al_alloc.c
+++ b/microblaze/common/al_alloc.c
@@ -16,7 +16,7 @@ MODULE_AUTHOR("Sebastien Alaiwan");
 MODULE_AUTHOR("Antoine Gruzelle");
 MODULE_DESCRIPTION("Allegro Common");
 
-struct al5_dma_buffer *al5_alloc_dma_(struct device *dev, size_t size)
+static struct al5_dma_buffer *al5_alloc_dma_(struct device *dev, size_t size)
 {
 	struct al5_dma_buffer *buf =
 		kmalloc(sizeof(struct al5_dma_buffer), GFP_KERNEL);

--- a/microblaze/common/al_char.c
+++ b/microblaze/common/al_char.c
@@ -4,6 +4,7 @@
 *
 ******************************************************************************/
 
+#include "al_char.h"
 #include "al_codec.h"
 
 int al5_setup_chrdev_region(int *major, int base_minor, int nb_devs, char *desc)

--- a/microblaze/common/al_codec.c
+++ b/microblaze/common/al_codec.c
@@ -17,6 +17,7 @@
 #include "al_alloc.h"
 #include "al_user.h"
 #include "mcu_interface.h"
+#include "l2_prefetch.h"
 
 #ifdef CONFIG_MEMORY_HOTPLUG
 #define HOTPLUG_ALIGN 0x40000000
@@ -183,11 +184,6 @@ static int alloc_mcu_caches(struct al5_codec_desc *codec)
 
 	return 0;
 }
-
-u32 get_l2_size_in_bits(void *);
-u32 get_l2_color_bitdepth(void *);
-u32 get_num_cores(void *);
-u32 get_core_frequency(void *);
 
 static void set_l2_info(struct device *dev, struct mcu_init_msg *init_msg)
 {

--- a/microblaze/common/al_codec.c
+++ b/microblaze/common/al_codec.c
@@ -15,6 +15,7 @@
 #include "mcu_utils.h"
 #include "al_codec.h"
 #include "al_alloc.h"
+#include "al_user.h"
 #include "mcu_interface.h"
 
 #ifdef CONFIG_MEMORY_HOTPLUG
@@ -340,7 +341,6 @@ int al5_codec_open(struct inode *inode, struct file *filp)
 }
 EXPORT_SYMBOL_GPL(al5_codec_open);
 
-void al5_user_destroy_channel_resources(struct al5_user *user);
 int al5_codec_release(struct inode *inode, struct file *filp)
 {
 	struct al5_filp_data *private_data = filp->private_data;

--- a/microblaze/common/al_codec.c
+++ b/microblaze/common/al_codec.c
@@ -427,7 +427,7 @@ release_firmware:
 }
 EXPORT_SYMBOL_GPL(al5_codec_set_firmware);
 
-int al5_setup_dma(struct al5_codec_desc *codec)
+static int al5_setup_dma(struct al5_codec_desc *codec)
 {
 	/* If there is a memory-region phandle, we use that memory to allocate our dma buffers
 	 * and if the hw ip supports it, we start the hw ip bus address range at the first address

--- a/microblaze/common/al_dmabuf.c
+++ b/microblaze/common/al_dmabuf.c
@@ -198,6 +198,7 @@ static void al5_dmabuf_release(struct dma_buf *buf)
 	kfree(dinfo);
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
 static void *al5_dmabuf_kmap(struct dma_buf *dmabuf, unsigned long page_num)
 {
 	struct al5_dmabuf_priv *dinfo = dmabuf->priv;
@@ -205,6 +206,7 @@ static void *al5_dmabuf_kmap(struct dma_buf *dmabuf, unsigned long page_num)
 
 	return vaddr + page_num * PAGE_SIZE;
 }
+#endif
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(5, 18, 0)
 static int al5_dmabuf_vmap(struct dma_buf *dbuf, struct iosys_map *map)

--- a/microblaze/common/al_group.c
+++ b/microblaze/common/al_group.c
@@ -143,13 +143,13 @@ fail:
 	dev_err(group->device, "Couldn't destroy orphan mcu channel\n");
 }
 
-void print_cannot_retrieve_user(struct device *dev, u32 mail_uid)
+static void print_cannot_retrieve_user(struct device *dev, u32 mail_uid)
 {
 	dev_err(dev, "Mail of uid %d received related to inexistent user\n",
 		mail_uid);
 }
 
-bool should_destroy_channel_on_bad_feedback(u32 mail_uid)
+static bool should_destroy_channel_on_bad_feedback(u32 mail_uid)
 {
 	switch (mail_uid) {
 	case AL_MCU_MSG_INIT:
@@ -161,7 +161,7 @@ bool should_destroy_channel_on_bad_feedback(u32 mail_uid)
 	}
 }
 
-struct al5_user *retrieve_user(struct al5_group *group, struct al5_mail *mail)
+static struct al5_user *retrieve_user(struct al5_group *group, struct al5_mail *mail)
 {
 	struct al5_user *user;
 	int user_uid, chan_uid = BAD_CHAN;
@@ -189,7 +189,7 @@ struct al5_user *retrieve_user(struct al5_group *group, struct al5_mail *mail)
 /* return -1 if we failed to retrieve the user, -ENOMEM if there was a memory
  * shortage and 0 otherwise */
 #define AL_NO_USER -1
-int try_to_deliver_to_user(struct al5_group *group, struct al5_mail *mail)
+static int try_to_deliver_to_user(struct al5_group *group, struct al5_mail *mail)
 {
 	struct al5_user *user;
 	int ret = AL_NO_USER;
@@ -217,7 +217,7 @@ unlock:
 	return ret;
 }
 
-void handle_mail(struct al5_group *group, struct al5_mail *mail)
+static void handle_mail(struct al5_group *group, struct al5_mail *mail)
 {
 	int error;
 	u32 mail_uid = al5_mail_get_uid(mail);
@@ -239,7 +239,7 @@ void handle_mail(struct al5_group *group, struct al5_mail *mail)
 			"Failed to deliver mail to the user (memory shortage). Skipping...\n");
 }
 
-void read_mail(struct al5_group *group)
+static void read_mail(struct al5_group *group)
 {
 	struct al5_mail *mail = al5_mcu_recv(group->mcu);
 

--- a/microblaze/common/al_group.c
+++ b/microblaze/common/al_group.c
@@ -12,6 +12,7 @@
 #include "al_mail.h"
 #include "al_codec_mails.h"
 #include "al_constants.h"
+#include "al_user.h"
 
 void al5_group_init(struct al5_group *group, struct mcu_mailbox_interface *mcu,
 		    int max_users_nb, struct device *device)
@@ -23,7 +24,6 @@ void al5_group_init(struct al5_group *group, struct mcu_mailbox_interface *mcu,
 	group->device = device;
 }
 
-void al5_user_destroy_channel_resources(struct al5_user *user);
 void al5_group_deinit(struct al5_group *group)
 {
 	int i;

--- a/microblaze/common/xil_clk.c
+++ b/microblaze/common/xil_clk.c
@@ -17,6 +17,7 @@
 #include <linux/regmap.h>
 #include <linux/clk.h>
 
+#include "xil_clk.h"
 #include "al_codec.h"
 
 #define VCU_PLL_CLK 0x34

--- a/microblaze/common/xil_l2_prefetch.c
+++ b/microblaze/common/xil_l2_prefetch.c
@@ -13,6 +13,8 @@
 #include <soc/xilinx/xlnx_vcu.h>
 #endif
 
+#include "l2_prefetch.h"
+
 #define MEMORY_WORD_SIZE_IN_BITS 32
 
 u32 get_l2_color_bitdepth(void *parent)

--- a/microblaze/include/al_char.h
+++ b/microblaze/include/al_char.h
@@ -7,6 +7,9 @@
 #ifndef _AL_CHAR_H_
 #define _AL_CHAR_H_
 
+#include <linux/fs.h>
+#include <linux/module.h>
+
 int al5_setup_chrdev_region(int *major, int minor, int nb_devs, char *desc);
 int al5_setup_cdev(struct cdev *cdev, const struct file_operations *fops,
 		   struct module *owner, int major, int minor);

--- a/microblaze/include/al_user.h
+++ b/microblaze/include/al_user.h
@@ -82,6 +82,7 @@ struct al5_user {
 void al5_user_init(struct al5_user *user, int uid,
 		   struct mcu_mailbox_interface *mcu, struct device *device);
 int al5_user_destroy_channel(struct al5_user *user, int quiet);
+void al5_user_destroy_channel_resources(struct al5_user *user);
 void al5_user_remove_residual_messages(struct al5_user *user);
 
 int al5_check_and_send(struct al5_user *user, struct al5_mail *mail);

--- a/microblaze/include/l2_prefetch.h
+++ b/microblaze/include/l2_prefetch.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
+#ifndef L2_PREFETCH_H
+#define L2_PREFETCH_H
+
+#include <linux/types.h>
+
+u32 get_l2_size_in_bits(void *);
+u32 get_l2_color_bitdepth(void *);
+u32 get_num_cores(void *);
+u32 get_core_frequency(void *);
+
+#endif // L2_PREFETCH_H


### PR DESCRIPTION
Hi,
I have noticed a bunch of warnings emitted when building the kernel module with gcc 14.2 (which already is not bleeding edge...). They are all trivially fixable as can be seen in the attached patches. Please take them upstream.

There is one remaining issue in my build system with the master branch: The stack frame of [`al5e_ioctl()`](https://github.com/Xilinx/vcu-modules/blob/432ac3d1578999a84ae96bb66c3ecdc0fe479867/microblaze/al5e/al_enc.c#L84) is too large (over 2KiB) mainly because of the local `struct al5_params params` and the `struct al5_params` embedded in `struct al5_config_channel config_channel`. Maybe you could reduce `OPAQUE_SIZE` to some saner but still safe levels or think about how to move the stuff away from the stack.

GLHF